### PR TITLE
Fixed issue with controller executable not in path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ bower_components
 .idea/
 *.iml
 docker-compose.override.yml
+shipyard

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,8 @@ clean:
 	@rm -rf controller/controller
 
 build:
-	@cd controller && go build -a -tags "netgo static_build" -installsuffix netgo -ldflags "-w -X github.com/shipyard/shipyard/version.GitCommit=$(COMMIT)" .
+	@go build -a -tags "netgo static_build" -installsuffix netgo -ldflags "-w -X github.com/shipyard/shipyard/version.GitCommit=$(COMMIT)" .
+	@mv shipyard controller/controller
 
 remote-build:
 	@docker build -t shipyard-build -f Dockerfile.build .
@@ -23,10 +24,10 @@ media:
 
 image: media build
 	@echo Building Shipyard image $(TAG)
-	@cd controller && docker build -t shipyard/shipyard:$(TAG) .
+	@cd controller && docker build -t shipyard/shipyard:$TAG .
 
 release: build image
-	@docker push shipyard/shipyard:$(TAG)
+	@docker push shipyard/shipyard:$TAG
 
 test: clean
  	# TODO: enable registry e2e when they use httptest e2e server instead of external container.

--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -1,7 +1,4 @@
 FROM alpine:3.3
-ENV http_proxy=http://web-proxy.il.hpecorp.net:8080 \
-    https_proxy=http://web-proxy.il.hpecorp.net:8080 \
-    no_proxy=127.0.0.1,localhost,hpeswlab.net,mydyumserver,mydyumserver.hpswlabs.adapps.hp.com,*.hp.com,16.59.0.0,hpswlabs.adapps.hp.com:80
 
 RUN apk add --update git ca-certificates && \
     rm -rf /var/cache/apk/*

--- a/main.go
+++ b/main.go
@@ -1,4 +1,4 @@
-package shipyard
+package main
 
 import (
 	"os"


### PR DESCRIPTION
The re-organization of the project introduced a bug when building the project in which the `mail.go` needed to be in `package main` to built as an executable. Also, this generates an executable `./shipyard` instead of the `./controller/controller` so that had to be renamed in the `Makefile` `build` to `./controller/controller`. 