### PR TITLE
Bugfix/fix image to registry relationships

### DIFF
--- a/client/images.go
+++ b/client/images.go
@@ -44,8 +44,7 @@ func GetImages(authHeader, url string) ([]model.Image, error) {
 
 func CreateImage(authHeader string, url string, name string, imageId string, tag string, ilmtags []string, description string, registryId string, location string, skipImageBuild bool, projectId string) (string, error) {
 
-	var image *model.Image
-	image = image.NewImage(name, imageId, tag, ilmtags, description, registryId, location, skipImageBuild, projectId)
+	image := model.NewImage(name, imageId, tag, ilmtags, description, registryId, location, skipImageBuild, projectId)
 	//make a request to create it
 	data, err := json.Marshal(image)
 	if err != nil {
@@ -70,8 +69,7 @@ func CreateImage(authHeader string, url string, name string, imageId string, tag
 
 func UpdateImage(authHeader string, url string, id string, name string, imageId string, tag string, ilmtags []string, description string, registryId string, location string, skipImageBuild bool, projectId string) error {
 
-	var image *model.Image
-	image = image.NewImage(name, imageId, tag, ilmtags, description, registryId, location, skipImageBuild, projectId)
+	image := model.NewImage(name, imageId, tag, ilmtags, description, registryId, location, skipImageBuild, projectId)
 	image.ID = id
 	data, err := json.Marshal(image)
 	if err != nil {

--- a/client/projects.go
+++ b/client/projects.go
@@ -110,10 +110,10 @@ func DeleteProject(authHeader, url, id string) (int, error) {
 	return resp.StatusCode, nil
 }
 
-func AddProjectImage(authHeader, url, projectId string, name string, imageId string, tag string, ilmtags []string, description string, registryId string, location string, skipImageBuild bool) (int, error) {
+func AddProjectImage(authHeader, url, projectId string, name string, imageId string, tag string, ilmtags []string,
+	description string, registryId string, location string, skipImageBuild bool) (int, error) {
 
-	var image *model.Image
-	newImage := image.NewImage(name, imageId, tag, ilmtags, description, registryId, location, skipImageBuild, projectId)
+	newImage := model.NewImage(name, imageId, tag, ilmtags, description, registryId, location, skipImageBuild, projectId)
 
 	data, err := json.Marshal(newImage)
 	if err != nil {

--- a/controller/api/projects_test.go
+++ b/controller/api/projects_test.go
@@ -363,7 +363,20 @@ func TestAddProjectImage(t *testing.T) {
 		So(code, ShouldEqual, http.StatusCreated)
 		So(err, ShouldBeNil)
 		Convey("When we add a new image to it", func() {
-			code, err := apiClient.AddProjectImage(SY_AUTHTOKEN, ts.URL, projectId, IMAGE1_NAME, "", IMAGE1_TAG, IMAGE1_DESC, IMAGE1_LOCATION, true)
+			code, err := apiClient.AddProjectImage(
+				SY_AUTHTOKEN,
+				ts.URL,
+				projectId,
+				IMAGE1_NAME,
+				"",
+				IMAGE1_TAG,
+				[]string{"latest", "awesomeTag"},
+				IMAGE1_DESC,
+				// TODO: it would be best to actually create a new registry object first and use that id.
+				"myregistryId123423412342",
+				IMAGE1_LOCATION,
+				true,
+			)
 			Convey("Then we should get a successful response", func() {
 				So(code, ShouldEqual, http.StatusCreated)
 				So(err, ShouldBeNil)
@@ -393,8 +406,17 @@ func TestAddProjectImageViaUpdate(t *testing.T) {
 		So(project, ShouldNotBeNil)
 		So(code, ShouldEqual, http.StatusOK)
 		Convey("When we add a new image in the project structure and request an update", func() {
-			var image *model.Image
-			newImage := image.NewImage(IMAGE2_NAME, "", IMAGE2_TAG, IMAGE2_DESC, IMAGE2_LOCATION, true, "")
+			newImage := model.NewImage(
+				IMAGE2_NAME,
+				"",
+				IMAGE2_TAG,
+				[]string{"latest", "awesomeTag"},
+				IMAGE2_DESC,
+				"myAmazingRegistryId1232323123",
+				IMAGE2_LOCATION,
+				true,
+				"",
+			)
 			project.Images = append(project.Images, newImage)
 			code, err := apiClient.UpdateProject(SY_AUTHTOKEN, ts.URL, PROJECT3_SAVED_ID, project.Name, project.Description, project.Status, project.Images, nil, true)
 			Convey("Then we should get a successful response", func() {
@@ -438,11 +460,29 @@ func TestAddProjectImageViaUpdate(t *testing.T) {
 
 func TestManagingProjectImagesNesting(t *testing.T) {
 	savedProjectId := ""
-	var busybox *model.Image
-	var alpine *model.Image
 	// TODO: refactor all of these hard-coded values to contants
-	busybox = busybox.NewImage("busybox", "23asdfsadf", "latest", "my busybox", "artifactory registry", true, "blank")
-	alpine = alpine.NewImage("alpine", "2asdfasf23423c", "latest", "my alpine", "DockerHub", true, "blank")
+	busybox := model.NewImage(
+		"busybox",
+		"23asdfsadf",
+		"latest",
+		[]string{"ilmTag1", "ilmTag2"},
+		"my busybox",
+		"myRegistryId424324243",
+		"artifactory registry",
+		true,
+		"blank",
+	)
+	alpine := model.NewImage(
+		"alpine",
+		"2asdfasf23423c",
+		"latest",
+		[]string{"ilmTag3", "ilmTag4"},
+		"my alpine",
+		"",
+		"DockerHub",
+		true,
+		"blank",
+	)
 
 	imageList := []*model.Image{}
 	imageList = append(imageList, busybox)

--- a/controller/api/swarm.go
+++ b/controller/api/swarm.go
@@ -44,6 +44,7 @@ func authConfigB64(username, password, auth, email string) (string, error) {
 
 // pingRegistry Performs a *ping* to a V2 registry by it's `/v2/` endpoint
 // It returns true if the ping is successful.
+// TODO: there are two pingRegistry() funcs one in API and another one in manager. Should refactor.
 func pingRegistry(registry, username, password string) (bool, error) {
 	registryEndpoint := registry + "/v2/"
 

--- a/controller/manager/manager.go
+++ b/controller/manager/manager.go
@@ -780,6 +780,7 @@ func (m DefaultManager) Node(name string) (*model.Node, error) {
 	return nil, nil
 }
 
+// TODO: this duplicated in the api package. Need to refactor into a util or client library.
 func (m DefaultManager) PingRegistry(registry *model.Registry) error {
 
 	// TODO: Please note the trailing forward slash / which is needed for Artifactory, else you get a 404.

--- a/controller/manager/utils.go
+++ b/controller/manager/utils.go
@@ -2,31 +2,12 @@ package manager
 
 import (
 	"crypto/sha256"
-	"crypto/tls"
-	"crypto/x509"
 	"encoding/hex"
 	"strings"
 	"time"
 
 	"github.com/shipyard/shipyard/model"
 )
-
-func getTLSConfig(caCert, sslCert, sslKey []byte) (*tls.Config, error) {
-	// TLS config
-	var tlsConfig tls.Config
-	tlsConfig.InsecureSkipVerify = true
-	certPool := x509.NewCertPool()
-
-	certPool.AppendCertsFromPEM(caCert)
-	tlsConfig.RootCAs = certPool
-	cert, err := tls.X509KeyPair(sslCert, sslKey)
-	if err != nil {
-		return &tlsConfig, err
-	}
-	tlsConfig.Certificates = []tls.Certificate{cert}
-
-	return &tlsConfig, nil
-}
 
 func generateId(n int) string {
 	hash := sha256.New()
@@ -102,13 +83,6 @@ func parseClusterNodes(driverStatus [][]string) ([]*model.Node, error) {
 	}
 
 	return nodes, nil
-}
-
-func constructPullableImageName(imageNameTag, registryAddress string) string {
-	if registryAddress == "" {
-		return imageNameTag
-	}
-	return formatRegistryDomain(registryAddress) + "/" + imageNameTag
 }
 
 func formatRegistryDomain(registryAddress string) string {

--- a/controller/mock_test/ilm_mock.go
+++ b/controller/mock_test/ilm_mock.go
@@ -130,9 +130,11 @@ func (m MockManager) GetImages(projectId string) ([]*model.Image, error) {
 	return nil, nil
 }
 
-func (m MockManager) PullImage(imageNameTag, address, username, password string) error {
+func (m MockManager) PullImage(pullableImageName string, username, password string) error {
 	return nil
 }
 func (m MockManager) UpdateImageIlmTags(projectId string, imageId string, ilmTag string) error {
 	return nil
 }
+func (m MockManager) GetRegistry(registryId string) (*model.Registry, error) { return nil, nil }
+func (m MockManager) PingRegistry(registry *model.Registry) error            { return nil }

--- a/controller/mock_test/ilm_mock.go
+++ b/controller/mock_test/ilm_mock.go
@@ -130,6 +130,9 @@ func (m MockManager) GetImages(projectId string) ([]*model.Image, error) {
 	return nil, nil
 }
 
-func (m MockManager) PullImage(imageNameAndTag string) error {
+func (m MockManager) PullImage(imageNameTag, address, username, password string) error {
+	return nil
+}
+func (m MockManager) UpdateImageIlmTags(projectId string, imageId string, ilmTag string) error {
 	return nil
 }

--- a/model/image.go
+++ b/model/image.go
@@ -45,5 +45,5 @@ func (i *Image) PullableName() string {
 	if i.RegistryDomain != "" {
 		prefix = i.RegistryDomain + "/"
 	}
-	return prefix + i.Name + "/" + i.Tag
+	return prefix + i.Name + ":" + i.Tag
 }

--- a/model/image.go
+++ b/model/image.go
@@ -8,6 +8,7 @@ type Image struct {
 	IlmTags        []string `json:"ilmTags" gorethink:"ilmTags"`
 	Description    string   `json:"description" gorethink:"description"`
 	RegistryId     string   `json:"registryId" gorethink:"registryId"`
+	RegistryDomain string   `json:"-" gorethink:"registryDomain"`
 	Location       string   `json:"location" gorethink:"location"`
 	SkipImageBuild bool     `json:"skipImageBuild" gorethink:"skipImageBuild"`
 	ProjectId      string   `json:"projectId" gorethink:"projectId"`
@@ -37,4 +38,12 @@ func NewImage(
 	image.ProjectId = projectId
 
 	return image
+}
+
+func (i *Image) PullableName() string {
+	prefix := ""
+	if i.RegistryDomain != "" {
+		prefix = i.RegistryDomain + "/"
+	}
+	return prefix + i.Name + "/" + i.Tag
 }

--- a/model/image.go
+++ b/model/image.go
@@ -13,7 +13,17 @@ type Image struct {
 	ProjectId      string   `json:"projectId" gorethink:"projectId"`
 }
 
-func (i *Image) NewImage(name string, imageId string, tag string, ilmTags []string, description string, registryId string, location string, skipImageBuild bool, projectId string) *Image {
+func NewImage(
+	name string,
+	imageId string,
+	tag string,
+	ilmTags []string,
+	description string,
+	registryId string,
+	location string,
+	skipImageBuild bool,
+	projectId string,
+) *Image {
 
 	image := new(Image)
 	image.Name = name


### PR DESCRIPTION
- Fixed associating an image to its registry and pulling up the correct domain info from the registry upon image CRUD.
- Fixed image doman + name + tag not being correctly constructed for images from a registry.
- Allowed defaulting to image not having a registryId, e.g. like DockerHub at the moment.