### PR TITLE
- `delete-test-modal` now displays the test's `name` in it's title

### DIFF
--- a/controller/static/app/projects/edit.html
+++ b/controller/static/app/projects/edit.html
@@ -20,7 +20,7 @@
 <div id="edit-project-delete-test-modal" class="ui small modal transition">
     <i class="close icon"></i>
     <div class="header">
-        Delete Test: {{ vm.selectedTest.id | limitTo:12 }}
+        Delete Test: {{ vm.selectedTest.name | limitTo:12 }}
     </div>
     <div class="content">
         <p>Are you sure you want to delete this test?</p>


### PR DESCRIPTION
fixes #87